### PR TITLE
Add DateStringCompat class for some HTC devices bug.

### DIFF
--- a/library/src/jp/mixi/compatibility/android/text/DateStringCompat.java
+++ b/library/src/jp/mixi/compatibility/android/text/DateStringCompat.java
@@ -1,0 +1,23 @@
+package jp.mixi.compatibility.android.text;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class DateStringCompat {
+    /**
+     * Some HTC devices return wrong formatted text from DateFormat.
+     * ex. DateFormat.format("MM月DD日", new Date("2013/1/25"))
+     *   => expected:<01月25[日]> but was:<01月25[]>
+     * As a workaround for HTC device's bug,
+     * this function uses {@link SimpleDateFormat} for now.
+     * 
+     * @param format please refer to the {@link SimpleDateFormat}
+     * @param date
+     * @return formatted string
+     */
+    public static String format(String format, Date date) {
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.US);
+        return sdf.format(date);
+    }
+}

--- a/library_test/src/jp/mixi/compatibility/test/DateStringCompatTest.java
+++ b/library_test/src/jp/mixi/compatibility/test/DateStringCompatTest.java
@@ -1,0 +1,17 @@
+package jp.mixi.compatibility.test;
+
+import java.util.Date;
+
+import jp.mixi.compatibility.android.text.DateStringCompat;
+
+import android.test.AndroidTestCase;
+
+public class DateStringCompatTest extends AndroidTestCase {
+    @SuppressWarnings("deprecation")
+    public void testformat() {
+        Date date = new Date("2013/2/25 7:25:50");
+        String format = "yyyy年MM月dd日hh時mm分ss秒";
+        String formatterdText = DateStringCompat.format(format, date);
+        assertEquals("2013年02月25日07時25分50秒", formatterdText);
+    }
+}


### PR DESCRIPTION
- Some HTC devices return wrong formatted text from DateFormat.
  ex. DateFormat.format("MM月DD日", new Date("2013/1/25"))
    => expected:<01月25[日]> but was:<01月25[]>
  So we should use SimpleDateFormat as a workaround for this bug at present.
