### PR TITLE
Pictures ディレクトリがない機種があるので再帰的に掘るようにした。

### DIFF
--- a/library/src/jp/mixi/compatibility/android/provider/MediaStoreCompat.java
+++ b/library/src/jp/mixi/compatibility/android/provider/MediaStoreCompat.java
@@ -85,7 +85,7 @@ public class MediaStoreCompat {
      * @return true if the device has a camera feature. false otherwise.
      */
     public boolean hasCameraFeature(Context context) {
-        PackageManager pm = context.getApplicationContext().getPackageManager();                                                                                                                        
+        PackageManager pm = context.getApplicationContext().getPackageManager();
         return pm.hasSystemFeature(PackageManager.FEATURE_CAMERA);
     }
 
@@ -353,7 +353,7 @@ public class MediaStoreCompat {
                 MEDIA_FILE_DIRECTORY);
 
         if (!extDir.exists()) {
-            if (!extDir.mkdir()) return null;
+            if (!extDir.mkdirs()) return null;
         }
 
         String timeStamp = new SimpleDateFormat(MEDIA_FILE_NAME_FORMAT).format(new Date());


### PR DESCRIPTION
Some devces has no /mnt/sdcard/'Pictures'/ directory. 
ex.
  Maker : SAMSUNG (docomo)
  Model number : SC-02B
  Firmware version : 2.3.6
  Baseband version : SC02BOMLC4
  Kernel version : 2.6.35.7-SC02BOMLC4-CL1052793 se.infra@SEI-46 #2
  Build number : GINGERBREAD.OMLC4

In this model mkdir() always returns false. It should be recursively, should it?
