### PR TITLE
Fix forgotten the photo uri assignment

### DIFF
--- a/library/src/jp/mixi/compatibility/android/provider/MediaStoreCompat.java
+++ b/library/src/jp/mixi/compatibility/android/provider/MediaStoreCompat.java
@@ -127,7 +127,9 @@ public class MediaStoreCompat {
         Uri captured = null;
         if (data != null) {
             captured = data.getData();
-            if (captured == null) data.getParcelableExtra(Intent.EXTRA_STREAM);
+            if (captured == null) {
+                captured = data.getParcelableExtra(Intent.EXTRA_STREAM);
+            }
         }
 
         File prepared = new File(preparedUri.toString());


### PR DESCRIPTION
Intent周りのバグでハマってAndroid-Device-Compatibilityを読んでいたら代入のし忘れ？を見つけたので修正しました。
